### PR TITLE
Dev Fund Fix

### DIFF
--- a/lib/blockUnlocker.js
+++ b/lib/blockUnlocker.js
@@ -65,15 +65,15 @@ function runInterval(){
             async.filter(blocks, function(block, mapCback){
                 var daemonType = config.daemonType ? config.daemonType.toLowerCase() : "default";
                 var blockHeight = (daemonType === "forknote" || daemonType === "bytecoin" || config.blockUnlocker.fixBlockHeightRPC) ? block.height + 1 : block.height;
-                apiInterfaces.rpcDaemon('getblockheaderbyheight', {height: blockHeight}, function(error, result){
+		apiInterfaces.rpcDaemon('getblock', {height: blockHeight}, function(error, result){
                     if (error){
-                        log('error', logSystem, 'Error with getblockheaderbyheight RPC request for block %s - %j', [block.serialized, error]);
+                        log('error', logSystem, 'Error with getblock RPC request for block %s - %j', [block.serialized, error]);
                         block.unlocked = false;
                         mapCback();
                         return;
                     }
                     if (!result.block_header){
-                        log('error', logSystem, 'Error with getblockheaderbyheight, no details returned for %s - %j', [block.serialized, result]);
+                        log('error', logSystem, 'Error with getblock, no details returned for %s - %j', [block.serialized, result]);
                         block.unlocked = false;
                         mapCback();
                         return;
@@ -81,11 +81,16 @@ function runInterval(){
                     var blockHeader = result.block_header;
                     block.orphaned = blockHeader.hash === block.hash ? 0 : 1;
                     block.unlocked = blockHeader.depth >= config.blockUnlocker.depth;
-                    block.reward = blockHeader.reward;
-                    if (config.blockUnlocker.networkFee) {
-                        var networkFeePercent = config.blockUnlocker.networkFee / 100;
-                        block.reward = block.reward - (block.reward * networkFeePercent);
-                    }
+
+		    var blockJson = JSON.parse(result.json);
+		    var minerTx = blockJson.miner_tx;
+		    if (minerTx.vout.length == 2) {
+			log('info', logSystem, 'Detected dev fund block, height %d', [blockHeight]);
+			block.reward = Math.min(minerTx.vout[0].amount, minerTx.vout[1].amount);
+		    } else {
+			block.reward = blockHeader.reward;
+		    }
+
                     mapCback(block.unlocked);
                 });
             }, function(unlockedBlocks){


### PR DESCRIPTION
This change to the block unlocker will check to see if there are two transactions in the mined block's reward. If there are, it means your pool mined the weekly dev reward block which in addition to the current 41.97 reward has a lump sum of 25,641 Ryo paid to the devs. 

If a block containing the dev reward is detected, this change will cause the pool to look at the lower amount, which is the 41.97 that your wallet will receive and that should be paid out to your miners. Should you not implement this fix, and your pool finds the weekly dev fund block, the software will think it should split the 25,641 Ryo as payments to your miners. Unless you hold an extra 25,641 Ryo in your pool's wallet, this will simply make your payments fail, and cause some manual work on your end to fix the balances of your users.